### PR TITLE
Use URLs instead of OS specific paths for importing

### DIFF
--- a/src/http/any-catchall/_get-elements.mjs
+++ b/src/http/any-catchall/_get-elements.mjs
@@ -27,7 +27,7 @@ export default async function getElements (basePath) {
 
   let head = exists(pathToHead) === false ?
     _head :
-    await import(pathToFileURL(pathToHead).href);
+    (await import(pathToFileURL(pathToHead).href)).default;
 
   if (exists(pathToModule)) {
     // read explicit elements manifest

--- a/src/http/any-catchall/_get-elements.mjs
+++ b/src/http/any-catchall/_get-elements.mjs
@@ -48,16 +48,21 @@ export default async function getElements (basePath) {
   }
 
   if (exists(pathToElements)) {
+    let elementsURL = new URL('file://')
+    elementsURL.pathname = basePath + '/'
+    elementsURL = new URL('elements', fileURL)
     // read all the elements
     let files = getFiles(basePath, 'elements').filter(f => f.includes('.mjs'))
     for (let e of files) {
       // turn foo/bar.mjs into foo-bar to make sure we have a legit tag name
-      let tag = e.replace(basePath + '/elements/', '').replace('.mjs', '').replace('/', '-')
+      const fileURL = new URL('file://')
+      fileURL.pathname = e
+      let tag = fileURL.pathname.replace(elementsURL.pathname, '').slice(1).replace(/.mjs$/, '').replace(/\//g, '-')
       if (/^[a-z][a-z0-9-]*$/.test(tag) === false) {
         throw Error(`Illegal element name "${tag}" must be lowercase alphanumeric dash`)
       }
       // import the element and add to the map
-      let mod = await import(e)
+      let mod = await import(fileURL.href)
       els[tag] = mod.default
     }
   }

--- a/src/http/any-catchall/_get-module.mjs
+++ b/src/http/any-catchall/_get-module.mjs
@@ -1,4 +1,5 @@
 import path from 'path'
+import { pathToFileURL } from 'url';
 
 import { pathToRegexp } from 'path-to-regexp'
 
@@ -20,11 +21,12 @@ export default function getModule (basePath, folder, route) {
     let raw = getFiles(basePath, folder).sort(sort)
 
     let base = path.join(basePath, folder)
-    let clean = f => f.replace(base, '')
+    let basePathname = pathToFileURL(base).pathname
+    let clean = f => f.replace(basePathname, '')
                       .replace(/index\.html|index\.mjs|\.mjs|\.html/, '')
                       .replace('$', ':')
                       .replace(/\/+$/, '')
-    let copy = raw.slice(0).map(clean).map(p => pathToRegexp(p))
+    let copy = raw.slice(0).map(p => pathToFileURL(p).pathname).map(clean).map(p => pathToRegexp(p))
 
     let index = 0
     let found = false

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -1,4 +1,5 @@
 import { readFileSync as read } from 'fs'
+import { pathToFileURL } from 'url';
 
 import arc from '@architect/functions'
 import enhance from '@enhance/ssr'
@@ -22,7 +23,7 @@ export default async function api (basePath, req) {
   if (apiPath) {
 
     // only import if the module exists and only run if export equals httpMethod
-    let mod = await import(apiPath)
+    let mod = await import(pathToFileURL(apiPath).href)
     let method = mod[req.method.toLowerCase()]
     if (method) {
 


### PR DESCRIPTION
This fixes 2 windows problems by moving to using URLs instead of paths:

1. makes sure string replacements work properly in windows by normalizing all `\\` to `/`.
2. importing via `import('c:\\...')` will blow up because it looks like `c:` is a protocol.

It looks a bit odd because it has to set pathname instead of use the constructor due to `?` or `#` in filepaths.