### PR TITLE
importTransform usage update

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -59,7 +59,7 @@ export default async function api (basePath, req) {
   const html = enhance({
     elements,
     scriptTransforms: [
-      importTransform({ map: arc.static })
+      importTransform({ lookup: arc.static })
     ],
     styleTransforms: [
       styleTransform


### PR DESCRIPTION
importTransform takes a `lookup` function, not `map`.
https://github.com/enhance-dev/enhance-import-transform/blob/main/index.mjs#L1

this is currently breaking any script that tries to
```js
import { myAwesomeLib } from '/_static/bundles/the-awesome-lib.mjs'
```

