### PR TITLE
Passes API state to head

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@enhance/arc-plugin-enhance",
       "version": "1.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@architect/functions": "^5.2.2",
         "@architect/plugin-bundles": "^3.1.1",

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -59,7 +59,7 @@ export default async function api (basePath, req) {
   // rendering an html page
   let { head, elements } = await getElements(basePath)
 
-  const initialState = state.json
+  const store = state.json
     ? state.json
     : {}
   const html = enhance({
@@ -70,7 +70,7 @@ export default async function api (basePath, req) {
     styleTransforms: [
       styleTransform
     ],
-    initialState
+    initialState: store
   })
 
   try {
@@ -83,10 +83,10 @@ export default async function api (basePath, req) {
       let body = ''
       if (fourOhFour && fourOhFour.includes('.html')) {
         let raw = read(fourOhFour).toString()
-        body = html`${ head({ req, status, error }) }${ raw }`
+        body = html`${ head({ req, status, error, store }) }${ raw }`
       }
       else {
-        body = html`${ head({ req, status, error }) }<page-404 error="${error}"></page-404>`
+        body = html`${ head({ req, status, error, store }) }<page-404 error="${error}"></page-404>`
       }
       return { status, html: body }
     }
@@ -94,14 +94,13 @@ export default async function api (basePath, req) {
     // 200
     const status = state.status || state.code || state.statusCode || 200
     let res = {}
-    const state = Object.assign(initialState, { req, status })
     if (pagePath.includes('.html')) {
       let raw = read(pagePath).toString()
-      res.html = html`${ head(state) }${ raw }`
+      res.html = html`${ head({ req, status, error, store }) }${ raw }`
     }
     else {
       let tag = getPageName(basePath, pagePath)
-      res.html = html`${ head(state) }<page-${ tag }></page-${ tag }>`
+      res.html = html`${ head({ req, status, error, store }) }<page-${ tag }></page-${ tag }>`
     }
     res.statusCode = status
     if (state.session) res.session = state.session
@@ -115,10 +114,10 @@ export default async function api (basePath, req) {
       let body = ''
       if (fiveHundred && fiveHundred.includes('.html')) {
         let raw = read(fiveHundred).toString()
-        body = html`${ head({ req, status, error }) }${ raw }`
+        body = html`${ head({ req, status, error, store }) }${ raw }`
       }
       else {
-        body = html`${ head({ req, status, error }) }<page-500 error="${ error }"></page-500>`
+        body = html`${ head({ req, status, error, store }) }<page-500 error="${ error }"></page-500>`
       }
       return { status, html: body }
   }

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -59,6 +59,9 @@ export default async function api (basePath, req) {
   // rendering an html page
   let { head, elements } = await getElements(basePath)
 
+  const initialState = state.json
+    ? state.json
+    : {}
   const html = enhance({
     elements,
     scriptTransforms: [
@@ -67,7 +70,7 @@ export default async function api (basePath, req) {
     styleTransforms: [
       styleTransform
     ],
-    initialState: state.json? state.json : {}
+    initialState
   })
 
   try {
@@ -80,10 +83,10 @@ export default async function api (basePath, req) {
       let body = ''
       if (fourOhFour && fourOhFour.includes('.html')) {
         let raw = read(fourOhFour).toString()
-        body = html`${ head(req, status, error) }${ raw }`
+        body = html`${ head({ req, status, error }) }${ raw }`
       }
       else {
-        body = html`${ head(req, status, error) }<page-404 error="${error}"></page-404>`
+        body = html`${ head({ req, status, error }) }<page-404 error="${error}"></page-404>`
       }
       return { status, html: body }
     }
@@ -91,13 +94,14 @@ export default async function api (basePath, req) {
     // 200
     const status = state.status || state.code || state.statusCode || 200
     let res = {}
+    const state = Object.assign(initialState, { req, status })
     if (pagePath.includes('.html')) {
       let raw = read(pagePath).toString()
-      res.html = html`${ head(req, status) }${ raw }`
+      res.html = html`${ head(state) }${ raw }`
     }
     else {
       let tag = getPageName(basePath, pagePath)
-      res.html = html`${ head(req, status) }<page-${ tag }></page-${ tag }>`
+      res.html = html`${ head(state) }<page-${ tag }></page-${ tag }>`
     }
     res.statusCode = status
     if (state.session) res.session = state.session
@@ -111,10 +115,10 @@ export default async function api (basePath, req) {
       let body = ''
       if (fiveHundred && fiveHundred.includes('.html')) {
         let raw = read(fiveHundred).toString()
-        body = html`${ head(req, status, error) }${ raw }`
+        body = html`${ head({ req, status, error }) }${ raw }`
       }
       else {
-        body = html`${ head(req, status, error) }<page-500 error="${ error }"></page-500>`
+        body = html`${ head({ req, status, error }) }<page-500 error="${ error }"></page-500>`
       }
       return { status, html: body }
   }

--- a/src/http/any-catchall/templates/head.mjs
+++ b/src/http/any-catchall/templates/head.mjs
@@ -2,7 +2,7 @@
 import arc from '@architect/functions'
 
 export default function Head (state) {
-  const { req, status, error } = state
+  const { req, status, error, store } = state
   return `
 <!DOCTYPE html>
 <html lang="en">

--- a/src/http/any-catchall/templates/head.mjs
+++ b/src/http/any-catchall/templates/head.mjs
@@ -1,7 +1,8 @@
 /* eslint-disable */
 import arc from '@architect/functions'
 
-export default function Head (req, status, error) {
+export default function Head (state) {
+  const { req, status, error } = state
   return `
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
This PR changes the API of the head component which is a "breaking change"
Users are mainly shielded from this since for most use cases the framework handles the changes.

For users that are customizing the head they will need to adhere to the new api of:
```
export default function Head(state) {
   const { req, status, error } = state
   return `
   ...
   `
}
```

The API response is merged with the existing keys so users can access data returned from their API route and use that to customize their head tag