### PR TITLE
Allow deep path parameters in _backfill-params.mjs (Fixes #19)

### DIFF
--- a/src/http/any-catchall/_backfill-params.mjs
+++ b/src/http/any-catchall/_backfill-params.mjs
@@ -21,13 +21,9 @@ export default function backfill (basePath, apiPath, pagePath, req) {
 
   // resolve matches with param names in tmpl
   let matches = copy.rawPath.match(pattern)
-  let parts = tmpl.split('/').filter(Boolean)
-  let index = 0
-  for (let p of parts) {
-    if (p.startsWith(':')) {
-      params[p.replace(':', '')] = matches[index]
-    }
-    index += 1
-  }
+  let parts = tmpl.split('/').filter((p) => p.includes(:))
+  parts.forEach((p, index) => {
+    params[p.replace(':', '')] = matches[index+1]
+  })
   return params
 }

--- a/src/http/any-catchall/_backfill-params.mjs
+++ b/src/http/any-catchall/_backfill-params.mjs
@@ -15,13 +15,13 @@ export default function backfill (basePath, apiPath, pagePath, req) {
   tmpl = tmpl.replace(base, '')
     .replace(/index\.mjs|\.mjs/, '')
     .replace(/(\/?)\$\$\/?$/, '$1(.*)')
-    .replace('$', ':')
+    .replaceAll(/\/\$(\w+)/g, "/:$1")
     .replace(/\/+$/, '')
   let pattern = pathToRegexp(tmpl)
 
   // resolve matches with param names in tmpl
   let matches = copy.rawPath.match(pattern)
-  let parts = tmpl.split('/').filter((p) => p.startsWith(:))
+  let parts = tmpl.split('/').filter((p) => p.startsWith(':'))
   parts.forEach((p, index) => {
     params[p.replace(':', '')] = matches[index+1]
   })

--- a/src/http/any-catchall/_backfill-params.mjs
+++ b/src/http/any-catchall/_backfill-params.mjs
@@ -15,7 +15,7 @@ export default function backfill (basePath, apiPath, pagePath, req) {
   tmpl = tmpl.replace(base, '')
     .replace(/index\.mjs|\.mjs/, '')
     .replace(/(\/?)\$\$\/?$/, '$1(.*)')
-    .replaceAll(/\/\$(\w+)/g, "/:$1")
+    .replace(/\/\$(\w+)/g, "/:$1")
     .replace(/\/+$/, '')
   let pattern = pathToRegexp(tmpl)
 

--- a/src/http/any-catchall/_backfill-params.mjs
+++ b/src/http/any-catchall/_backfill-params.mjs
@@ -21,7 +21,7 @@ export default function backfill (basePath, apiPath, pagePath, req) {
 
   // resolve matches with param names in tmpl
   let matches = copy.rawPath.match(pattern)
-  let parts = tmpl.split('/').filter((p) => p.includes(:))
+  let parts = tmpl.split('/').filter((p) => p.startsWith(:))
   parts.forEach((p, index) => {
     params[p.replace(':', '')] = matches[index+1]
   })

--- a/test/backfill-params.mjs
+++ b/test/backfill-params.mjs
@@ -1,0 +1,52 @@
+import test from "tape";
+import url from "url";
+import path from "path";
+import backfill from "../src/http/any-catchall/_backfill-params.mjs";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+test("backfill - null case", async (t) => {
+  t.plan(1);
+  let basePath = path.join(__dirname, "..", "app");
+  let apiPath = path.join(basePath, "/api/foo");
+  let pagePath = undefined;
+  let req = {
+    rawPath: "/foo",
+    params: {},
+  };
+
+  let params = backfill(basePath, apiPath, pagePath, req);
+  t.deepEqual(params, req.params, "No params in null case");
+});
+
+test("backfill - one level '/api/foo/$id'", async (t) => {
+  t.plan(1);
+  let basePath = path.join(__dirname, "..", "app");
+  let apiPath = path.join(basePath, "/api/foo/$id");
+  let pagePath = undefined;
+  let req = {
+    rawPath: "/foo/5",
+    params: {},
+  };
+
+  let params = backfill(basePath, apiPath, pagePath, req);
+  t.deepEqual(params, { id: "5" }, "$id param parsed correctly");
+});
+
+test("backfill - pathological '/api/foo/$first/bar/$second/baz/$third'", async (t) => {
+  t.plan(1);
+  let basePath = path.join(__dirname, "..", "app");
+  let apiPath = path.join(basePath, "/api/foo/$first/bar/$second/baz/$third");
+  let pagePath = undefined;
+  let req = {
+    rawPath: "/foo/5/bar/6/baz/7",
+    params: {},
+  };
+
+  let params = backfill(basePath, apiPath, pagePath, req);
+  t.deepEqual(
+    params,
+    { first: "5", second: "6", third: "7" },
+    "all params parsed correctly"
+  );
+});


### PR DESCRIPTION
This PR updates the parts filter to only include parts that need to be matched, and changes the offset of the matches index so that the first "match" (the string that was matched) is ignored.