### PR TITLE
Prevent API path from pointing to `@architect/views/api/`-directory

### DIFF
--- a/src/http/any-catchall/_get-module.mjs
+++ b/src/http/any-catchall/_get-module.mjs
@@ -11,7 +11,7 @@ import clean from './_clean.mjs'
 const cache = {}
 
 /** helper to get module for given folder/route */
-export default function getModule (basePath, folder, route) {
+export default function getModule (basePath, folder, route, allowFolder = true) {
   // console.time('getModule')
 
   if (!cache[folder])
@@ -19,7 +19,9 @@ export default function getModule (basePath, folder, route) {
 
   if (!cache[folder][route]) {
 
-    let raw = getFiles(basePath, folder).sort(sort)
+    let raw = getFiles(basePath, folder)
+      .filter(p => allowFolder || p.endsWith('/') === false)
+      .sort(sort)
     let base = path.join(basePath, folder)
     let basePathname = pathToFileURL(base).pathname
 

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -15,7 +15,7 @@ import render from './_render.mjs'
 
 export default async function api (basePath, req) {
 
-  let apiPath = getModule(basePath, 'api', req.rawPath)
+  let apiPath = getModule(basePath, 'api', req.rawPath, false)
   let pagePath = getModule(basePath, 'pages', req.rawPath)
 
   let state = {}


### PR DESCRIPTION
This change prevents `@enhance` from ending up trying to import the `@architect/views/api/`-directory when the root page `/` is requested and there's no `app/api/index.mjs` in the project.