### PR TITLE
mount bundles.sandbox.watcher in host plugin

### DIFF
--- a/src/plugins/beginner.js
+++ b/src/plugins/beginner.js
@@ -8,6 +8,10 @@ module.exports = {
     async start (params) {
       await bundles.sandbox.start(params)
       await styles.sandbox.start(params)
+    },
+
+    async watcher (params) {
+      await bundles.sandbox.watcher(params)
     }
   },
 


### PR DESCRIPTION
`@architect/plugin-bundles` now has a sandbox watcher that can be attached to this plugin's hooks into Sandbox lifecycle events.