### PR TITLE
Guard against directory import

### DIFF
--- a/src/http/any-catchall/_get-files.mjs
+++ b/src/http/any-catchall/_get-files.mjs
@@ -7,7 +7,7 @@ let cache = {}
 export default function getFiles (basePath, folder) {
   if (!cache[folder]) {
     let root = join(basePath, folder)
-    let raw = glob.sync('/**', { dot: false, root })
+    let raw = glob.sync('/**', { dot: false, root, nodir: true })
     let files = raw.filter(f => f.includes('.'))
     // Glob fixed path normalization, but in order to match in Windows we need to re-normalize back to backslashes (lol)
     let isWin = process.platform.startsWith('win')

--- a/src/http/any-catchall/_get-module.mjs
+++ b/src/http/any-catchall/_get-module.mjs
@@ -1,4 +1,3 @@
-import { statSync } from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url';
 
@@ -37,8 +36,8 @@ export default function getModule (basePath, folder, route) {
       index += 1
     }
 
-    if (found && statSync(found).isFile()) {
-        cache[folder][route] = found
+    if (found) {
+      cache[folder][route] = found
     }
   }
 

--- a/src/http/any-catchall/_get-module.mjs
+++ b/src/http/any-catchall/_get-module.mjs
@@ -1,3 +1,4 @@
+import { statSync } from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url';
 
@@ -36,8 +37,8 @@ export default function getModule (basePath, folder, route) {
       index += 1
     }
 
-    if (found) {
-      cache[folder][route] = found
+    if (found && statSync(found).isFile()) {
+        cache[folder][route] = found
     }
   }
 

--- a/test/_get-module.mjs
+++ b/test/_get-module.mjs
@@ -33,3 +33,11 @@ test('getModules catchall', async t => {
   t.equal(expected, result, 'Got the catchall')
 })
 
+test('getModules no api', async t => {
+  t.plan(1)
+  let base = path.join(process.cwd(), 'test', 'mock-apps','app')
+  let folder = 'api'
+  let expected = false
+  let result = await getModule(base, folder, '/')
+  t.equal(expected, result, 'No api')
+})

--- a/test/mock-apps/app/api/docs/$$.mjs
+++ b/test/mock-apps/app/api/docs/$$.mjs
@@ -1,0 +1,13 @@
+// View documentation at: https://enhance.dev/docs/learn/starter-project/api
+/**
+ * @typedef {import('@enhance/types').EnhanceApiFn} EnhanceApiFn
+ */
+
+/**
+ * @type {EnhanceApiFn}
+ */
+ export async function get () {
+    return {
+      json: { data: ['fred', 'joe', 'mary'] }
+    }
+  }

--- a/test/mock-apps/app/pages/docs/index.html
+++ b/test/mock-apps/app/pages/docs/index.html
@@ -1,0 +1,1 @@
+<div>docs page</div>

--- a/test/mock-apps/app/pages/index.html
+++ b/test/mock-apps/app/pages/index.html
@@ -1,0 +1,1 @@
+<div>a page</div>


### PR DESCRIPTION
Ran into this problem when my app went from this state:

```
app
└── pages
    └── index.html
```

to this state:

```
app
├── api 
│   └── docs
│        └── $$.mjs
└── pages 
    ├── docs
    │     └── $$.mjs
    └── index.html
```

Hitting the docs catchall works great but then trying to load index.html it errors out with:

```
Error
Directory import '/project/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/node_modules/@architect/views/api/' 
is not supported resolving ES modules imported from /project/begin.com/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/router.mjs
```

Since the api folder now exists trying to load `pages/index.html` will try to find the corresponding api route which results in a folder, not a file, so the import barfs.

My fix is to ensure that any path returned from getModule is a file and not a directory.