### PR TITLE
Add session to store

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -41,6 +41,10 @@ export default async function api (basePath, req) {
       // if the api route does nothing backfill empty json response
       if (!state) state = { json:{} }
 
+      // add session to state
+      if (!state.json) state.json = {}
+      state.json.session = req.session || {}
+
       // if the user-agent requested json return the response immediately
       if (isJSON(req.headers)) {
         delete state.location
@@ -63,6 +67,9 @@ export default async function api (basePath, req) {
   const store = state.json
     ? state.json
     : {}
+  // add session to store
+  store.session = req.session || {}
+
   function html(str, ...values) {
     const _html = enhance({
       elements,


### PR DESCRIPTION
This three line change adds the `req.session` into the store. This is super useful for components that depend on data from the session. The main use case is authentication. I don't want to have to create an API route for every page that needs my account information so the API can read the session and add it to the store. This change makes it automatic.

So a login button could look like:

```javascript
export default function BeginLogin({ html, state }) {
  const { store } = state
  const { session } = store
  const { account } = session

  return html`<li>${ account ?
    `<a href="/logout">Log Out</a>` :
    `<a href="https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&scopes=read:user">Log In</a>`}</li>
    `
}
```

Signed-off-by: macdonst <simon.macdonald@gmail.com>