### PR TITLE
WIP: Export Router with alternate file tree

### DIFF
--- a/app/pages/test/$$.mjs
+++ b/app/pages/test/$$.mjs
@@ -1,0 +1,3 @@
+export default function({html,state}) {
+  return html`<div>stuff</div>`
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@enhance/arc-plugin-enhance",
   "version": "4.0.0",
   "main": "src/plugins/beginner.js",
+  "exports":{
+     ".": "./src/plugins/beginner.js",
+     "./src/http/any-catchall/router.mjs": "./src/http/any-catchall/router.mjs"
+  },
   "license": "Apache-2.0",
   "homepage": "https://enhance.dev",
   "repository": {

--- a/src/http/any-catchall/_get-elements.mjs
+++ b/src/http/any-catchall/_get-elements.mjs
@@ -69,10 +69,6 @@ export default async function getElements (basePath) {
       }
     }
   }
-  else {
-    // throw to warn we cannot find pages
-    throw Error('cannot find `/pages` folder')
-  }
 
   if (exists(pathToElements)) {
     let elementsURL = pathToFileURL(join(basePath, 'elements'));

--- a/src/http/any-catchall/_get-files.mjs
+++ b/src/http/any-catchall/_get-files.mjs
@@ -5,14 +5,15 @@ let cache = {}
 
 /** helper to return files from basePath */
 export default function getFiles (basePath, folder) {
-  if (!cache[folder]) {
+  if(!cache[basePath]) cache[basePath] = {}
+  if (!cache[basePath][folder]) {
     let root = join(basePath, folder)
     let raw = glob.sync('/**', { dot: false, root, nodir: true })
     let files = raw.filter(f => f.includes('.'))
     // Glob fixed path normalization, but in order to match in Windows we need to re-normalize back to backslashes (lol)
     let isWin = process.platform.startsWith('win')
     if (isWin) files = files.map(p => p.replace(/\//g, '\\'))
-    cache[folder] = files
+    cache[basePath][folder] = files
   }
-  return cache[folder]
+  return cache[basePath][folder]
 }

--- a/src/http/any-catchall/_get-module.mjs
+++ b/src/http/any-catchall/_get-module.mjs
@@ -14,10 +14,13 @@ const cache = {}
 export default function getModule (basePath, folder, route) {
   // console.time('getModule')
 
-  if (!cache[folder])
-    cache[folder] = {}
+  if (!cache[basePath])
+    cache[basePath] = {}
 
-  if (!cache[folder][route]) {
+  if (!cache[basePath][folder])
+    cache[basePath][folder] = {}
+
+  if (!cache[basePath][folder][route]) {
 
     let raw = getFiles(basePath, folder).sort(sort)
     let base = path.join(basePath, folder)
@@ -37,10 +40,10 @@ export default function getModule (basePath, folder, route) {
     }
 
     if (found) {
-      cache[folder][route] = found
+      cache[basePath][folder][route] = found
     }
   }
 
   // console.timeEnd('getModule')
-  return cache[folder][route] || false
+  return cache[basePath][folder][route] || false
 }

--- a/src/http/any-catchall/_render.mjs
+++ b/src/http/any-catchall/_render.mjs
@@ -1,7 +1,7 @@
 import router from './router.mjs'
 
 export default async function render (basePath, rawPath, session) {
-  let res = await router(basePath, {
+  let res = await router({basePath}, {
     rawPath,
     method: 'GET',
     headers: {

--- a/src/http/any-catchall/_sort-routes.mjs
+++ b/src/http/any-catchall/_sort-routes.mjs
@@ -21,10 +21,17 @@ export default function sorter(a, b) {
     // i.e. /test/$$.mjs = 3.1
     return str.split('/').reduce((prev, curr, i) => {
       return (prev + (pathPartWeight(curr) / Math.pow(10, i)))
-    }, 0)
+    }, 0) 
   }
 
+  const aWeight = totalWeightByPosition(a)
+  const bWeight = totalWeightByPosition(b)
 
-  return totalWeightByPosition(a) < totalWeightByPosition(b) ?1 : -1
+  let output
+  if (aWeight < bWeight) output = 1
+  if (aWeight > bWeight) output = -1
+  if (aWeight === bWeight) output = 0
+
+  return output
 
 }

--- a/src/http/any-catchall/index.mjs
+++ b/src/http/any-catchall/index.mjs
@@ -8,7 +8,7 @@ export function createRouter (base) {
     let here = path.dirname(url.fileURLToPath(import.meta.url))
     base = path.join(here, 'node_modules', '@architect', 'views')
   }
-  return arc.http.async(router.bind({}, base))
+  return arc.http.async(router.bind({}, {basePath:base}))
 }
 
 export const handler = createRouter() 

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -13,25 +13,49 @@ import isJSON from './_is-json-request.mjs'
 import backfill from './_backfill-params.mjs'
 import render from './_render.mjs'
 import fingerprintPaths from './_fingerprint-paths.mjs'
-import sort from './_sort-routes.mjs'
+import compareRoute from './_sort-routes.mjs'
 import path from 'path'
 
-export default async function api (basePath, req) {
+export default async function api (options, req) {
+  const { basePath, altPath } = options
 
   let apiPath = getModule(basePath, 'api', req.rawPath)
   let pagePath = getModule(basePath, 'pages', req.rawPath)
+
+  let apiBaseUsed = basePath
+  let pageBaseUsed = basePath
+  if (altPath){
+    const apiPathPart = apiPath && apiPath.replace(path.join(basePath,'api'),'')
+    const pagePathPart = pagePath && pagePath.replace(path.join(basePath,'pages'),'')
+
+    const altApiPath = getModule(altPath, 'api', req.rawPath)
+    const altPagePath = getModule(altPath, 'pages', req.rawPath)
+    const altApiPathPart = altApiPath && altApiPath.replace(path.join(altPath,'api'),'')
+    const altPagePathPart = altPagePath && altPagePath.replace(path.join(altPath,'pages'),'')
+    if (!apiPath && altApiPath) {
+      apiPath = altApiPath
+      apiBaseUsed = altPath
+    } else if (apiPath && altApiPath && (compareRoute(apiPathPart,altApiPathPart)===-1)) {
+      apiPath = altApiPath
+      apiBaseUsed = altPath
+    }
+    if (!pagePath && altPagePath) {
+      pagePath = altPagePath
+      pageBaseUsed = altPath
+    } else if (pagePath && altPagePath && (compareRoute(pagePathPart,altPagePathPart)===-1)) {
+      pagePath = altPagePath
+      pageBaseUsed = altPath
+    }
+  }
 
   // if both are defined but match with different specificity
   // (i.e. one is exact and one is a catchall)
   // only the most specific route will match
   if (apiPath && pagePath){
-    const apiPathPart = apiPath.replace(path.join(basePath,'api'),'')
-    const pagePathPart = pagePath.replace(path.join(basePath,'pages'),'')
-    if (sort(apiPathPart,pagePathPart)===1) {
-      apiPath = false
-    } else if (sort(pagePathPart,apiPathPart)===1) {
-      pagePath = false
-    }
+    const apiPathPart = apiPath.replace(path.join(apiBaseUsed,'api'),'')
+    const pagePathPart = pagePath.replace(path.join(pageBaseUsed,'pages'),'')
+    if (compareRoute(apiPathPart,pagePathPart)===1) apiPath = false
+    if (compareRoute(apiPathPart,pagePathPart)===-1) pagePath = false
   }
 
   let state = {}
@@ -54,10 +78,10 @@ export default async function api (basePath, req) {
     if (method) {
 
       // check to see if we need to modify the req and add in params
-      req.params = backfill(basePath, apiPath, pagePath, req)
+      req.params = backfill(apiBaseUsed, apiPath, '', req)
 
       // grab the state from the app/api route
-      let res =  render.bind({}, basePath)
+      let res =  render.bind({}, apiBaseUsed)
       state = await method(req, res)
 
       // if the api route does nothing backfill empty json response
@@ -80,7 +104,11 @@ export default async function api (basePath, req) {
   }
 
   // rendering an html page
-  let { head, elements } = await getElements(basePath)
+  const baseHeadElements = await getElements(basePath)
+  let altHeadElements = {}
+  if (altPath) altHeadElements = await getElements(altPath)
+  const head = baseHeadElements.head || altHeadElements.head
+  const elements = {...altHeadElements.elements,...baseHeadElements.elements}
 
   const store = state.json
     ? state.json
@@ -105,7 +133,8 @@ export default async function api (basePath, req) {
     if (!pagePath || state.code === 404 || state.status === 404 || state.statusCode === 404) {
       const status = 404
       const error = `${req.rawPath} not found`
-      const fourOhFour = getModule(basePath, 'pages', '/404')
+      let fourOhFour = getModule(basePath, 'pages', '/404')
+      if (altPath && !fourOhFour) fourOhFour = getModule(altPath, 'pages', '/404')
       let body = ''
       if (fourOhFour && fourOhFour.includes('.html')) {
         let raw = read(fourOhFour).toString()
@@ -126,7 +155,7 @@ export default async function api (basePath, req) {
       res.html = html`${ head({ req, status, error, store }) }${ raw }`
     }
     else {
-      let tag = getPageName(basePath, pagePath)
+      let tag = getPageName(pageBaseUsed, pagePath)
       res.html = html`${ head({ req, status, error, store }) }<page-${ tag }></page-${ tag }>`
     }
     res.statusCode = status
@@ -137,7 +166,8 @@ export default async function api (basePath, req) {
     // 500
     const status = 500
     const error = err.message || ''
-    const fiveHundred = getModule(basePath, 'pages', '/500')
+    let fiveHundred = getModule(basePath, 'pages', '/500')
+    if (altPath && !fiveHundred) fiveHundred = getModule(altPath, 'pages', '/500')
     let body = ''
     if (fiveHundred && fiveHundred.includes('.html')) {
       let raw = read(fiveHundred).toString()

--- a/test/_sort-routes.mjs
+++ b/test/_sort-routes.mjs
@@ -7,8 +7,9 @@ test('sorter', t => {
     'index.mjs',
     'views/index.mjs',
     'views/pages/books/index.mjs',
-    'views/pages/books/ack.mjs',
     'views/pages/books/new.mjs',
+    'views/pages/books/ack.mjs',
+    'views/pages/books/back.mjs',
     'views/pages/books/$id/arg.mjs', 
     'views/pages/books/$id.mjs', 
     'views/pages/books/$$.mjs',
@@ -19,7 +20,23 @@ test('sorter', t => {
     'views/$$.mjs',
     '$$.mjs',
   ]
-  const bad = good.slice().reverse()
+  const bad = [
+    '$$.mjs',
+    'views/$$.mjs',
+    'views/pages/$$.mjs',
+    'views/pages/$thing/$id/$place.mjs', 
+    'views/pages/$thing/id/$place.mjs', 
+    'views/pages/$thing/food/arg.mjs', 
+    'views/pages/books/$$.mjs',
+    'views/pages/books/$id.mjs', 
+    'views/pages/books/$id/arg.mjs', 
+    'views/pages/books/new.mjs',
+    'views/pages/books/ack.mjs',
+    'views/pages/books/back.mjs',
+    'views/pages/books/index.mjs',
+    'views/index.mjs',
+    'index.mjs',
+  ]
 
   let result = bad.sort(sorter)
 

--- a/test/mock-apps/app/api/about.mjs
+++ b/test/mock-apps/app/api/about.mjs
@@ -1,0 +1,5 @@
+export async function get (req) {
+  return {
+    json: { people: ['backup'] }
+  }
+}

--- a/test/mock-apps/app/api/backup-data.mjs
+++ b/test/mock-apps/app/api/backup-data.mjs
@@ -1,0 +1,13 @@
+// View documentation at: https://enhance.dev/docs/learn/starter-project/api
+/**
+ * @typedef {import('@enhance/types').EnhanceApiFn} EnhanceApiFn
+ */
+
+/**
+ * @type {EnhanceApiFn}
+ */
+ export async function get () {
+    return {
+      json: { data: ['fred', 'joe', 'mary'] }
+    }
+  }

--- a/test/router-alternate-path.mjs
+++ b/test/router-alternate-path.mjs
@@ -1,0 +1,143 @@
+import test from 'tape'
+import url from 'url'
+import path from 'path'
+import router from '../src/http/any-catchall/router.mjs'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+test('router with result in both', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/about',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router.bind({}, {basePath,altPath})(req)
+  t.ok(result.html.includes("fred"), 'got the right page')
+})
+
+test('router with result in both reversed', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/about',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router.bind({}, {basePath:altPath,altPath:basePath})(req)
+  t.ok(result.html.includes("backup"), 'got the right page')
+})
+
+test('router with result in alternative', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/backup-data',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router.bind({}, {basePath,altPath})(req)
+  t.ok(result.json.data.includes("fred"), 'got the right page')
+})
+
+test('router with result in both reversed', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/about',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router.bind({}, {basePath:altPath,altPath:basePath})(req)
+  console.log(result)
+  t.ok(result.html.includes("backup"), 'got the right page')
+})
+
+test('router with result in alternative', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/backup-data',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router({basePath,altPath}, req)
+  t.deepEqual(result.json.data,['fred', 'joe', 'mary'], 'got result')
+})
+
+test('router with no pages dir', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let primaryApp = path.join(__dirname, '..', 'app')
+  let secondaryApp = path.join(__dirname, 'mock-folders', 'app')
+  let result = await router({basePath:primaryApp, altPath:secondaryApp}, req)
+  t.ok(result, 'got result')
+})
+
+test('router with result in both reversed', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/about',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router.bind({}, {basePath:altPath,altPath:basePath})(req)
+  console.log(result)
+  t.ok(result.html.includes("backup"), 'got the right page')
+})
+
+test('router with result in alternative', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/backup-data',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let basePath = path.join(__dirname, '..', 'app')
+  let altPath = path.join(__dirname, 'mock-apps', 'app')
+  let result = await router({basePath,altPath}, req)
+  t.deepEqual(result.json.data,['fred', 'joe', 'mary'], 'got result')
+})
+
+test('router with no pages dir', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let primaryApp = path.join(__dirname, '..', 'app')
+  let secondaryApp = path.join(__dirname, 'mock-folders', 'app')
+  let result = await router({basePath:primaryApp, altPath:secondaryApp}, req)
+  t.ok(result, 'got result')
+})

--- a/test/router.mjs
+++ b/test/router.mjs
@@ -15,7 +15,22 @@ test('router', async t => {
     }
   }
   let base = path.join(__dirname, '..', 'app')
-  let result = await router(base, req)
+  let result = await router({basePath:base}, req)
+  t.ok(result, 'got result')
+  console.log(result)
+})
+
+test('router with no pages folder', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let base = path.join(__dirname, 'mock-folders', 'app')
+  let result = await router({basePath:base}, req)
   t.ok(result, 'got result')
   console.log(result)
 })


### PR DESCRIPTION
This includes an exportable version of the router that can be used in a plugin for instance to have alternate routes that can be overridden in the main routing structure.