### PR TITLE
use new plugin-styles 2.2 helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     ".arc"
   ],
   "dependencies": {
-    "@architect/asap": "^5.0.2",
-    "@architect/functions": "^5.2.3",
+    "@architect/asap": "^5.1.0",
+    "@architect/functions": "^5.3.1",
     "@architect/plugin-bundles": "^3.2.0",
-    "@begin/data": "^4.0.1",
-    "@enhance/arc-plugin-styles": "^2.0.2",
+    "@begin/data": "^4.0.2",
+    "@enhance/arc-plugin-styles": "experimental",
     "@enhance/enhance-style-transform": "^0.0.1",
     "@enhance/import-transform": "^4.0.0",
     "@enhance/ssr": "^3.0.9",
@@ -38,8 +38,8 @@
     "pluralize": "^8.0.0"
   },
   "devDependencies": {
-    "@architect/sandbox": "^5.3.4",
-    "eslint": "^8.26.0",
+    "@architect/sandbox": "^5.4.1",
+    "eslint": "^8.28.0",
     "tap-arc": "^0.3.5",
     "tape": "^5.6.1",
     "tiny-json-http": "^7.4.2"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@architect/functions": "^5.3.1",
     "@architect/plugin-bundles": "^3.2.0",
     "@begin/data": "^4.0.2",
-    "@enhance/arc-plugin-styles": "experimental",
+    "@enhance/arc-plugin-styles": "^2.2.0",
     "@enhance/enhance-style-transform": "^0.0.1",
     "@enhance/import-transform": "^4.0.0",
     "@enhance/ssr": "^3.0.9",

--- a/src/http/any-catchall/templates/head.mjs
+++ b/src/http/any-catchall/templates/head.mjs
@@ -1,9 +1,9 @@
-import { styles }  from '@enhance/arc-plugin-styles'
+import { getStyles }  from '@enhance/arc-plugin-styles'
 
 export default function Head() {
-  const appStyles = process.env.ARC_LOCAL
-    ? styles.getLinkTag()
-    : styles.getStyleTag()
+  const styles = process.env.ARC_LOCAL
+    ? getStyles.linkTag()
+    : getStyles.styleTag()
 
   return `
 <!DOCTYPE html>
@@ -12,7 +12,7 @@ export default function Head() {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title></title>
-  ${ appStyles }
+  ${ styles }
   <link rel="icon" href="/_public/favicon.svg">
 </head>
 `

--- a/src/http/any-catchall/templates/head.mjs
+++ b/src/http/any-catchall/templates/head.mjs
@@ -1,9 +1,9 @@
-import {   getLinkTag, getStyleTag }  from '@enhance/arc-plugin-styles/get-styles'
+import { styles }  from '@enhance/arc-plugin-styles'
 
 export default function Head() {
-  const styles = process.env.ARC_LOCAL
-    ? getLinkTag()
-    : getStyleTag()
+  const appStyles = process.env.ARC_LOCAL
+    ? styles.getLinkTag()
+    : styles.getStyleTag()
 
   return `
 <!DOCTYPE html>
@@ -12,7 +12,7 @@ export default function Head() {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title></title>
-  ${ styles }
+  ${ appStyles }
   <link rel="icon" href="/_public/favicon.svg">
 </head>
 `


### PR DESCRIPTION
The updated styles helper interface will improve the experience a good bit.  
Also, the output is quieter if the generated CSS file isn't found by helpers (like when a test runs the head.mjs file without Sandbox running)

~~relies on https://github.com/enhance-dev/arc-plugin-styles/pull/7~~