### PR TITLE
Resolves issue preventing session object being written to _idx cookie…

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -59,6 +59,7 @@ export default async function api (options, req) {
   }
 
   let state = {}
+  let isAsyncMiddleware = false
 
   // rendering a json response or passing state to an html response
   if (apiPath) {
@@ -73,7 +74,8 @@ export default async function api (options, req) {
     }
 
     let method = mod[req.method.toLowerCase()]
-    if (Array.isArray(method))
+    isAsyncMiddleware = Array.isArray(method)
+    if (isAsyncMiddleware)
       method = arc.http.async.apply(null, method)
     if (method) {
 
@@ -160,6 +162,7 @@ export default async function api (options, req) {
     }
     res.statusCode = status
     if (state.session) res.session = state.session
+    if (isAsyncMiddleware) res.headers = {'set-cookie': state.headers['set-cookie']}
     return res
   }
   catch (err) {


### PR DESCRIPTION
This resolves #53 

As the middleware methods are already run through `arc.http.async` the session object has already been converted and written as `set-cookie` in the headers object

However, this is currently discarded as the current code is only expecting to obtain session from `state.session` (which no longer exists). 

eg if state is console logged at router.mjs ln 133, during an async function, it would look like:

```
{
  headers: {
    'content-type': 'application/json; charset=utf8',
    'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0',
    'content-encoding': 'br',
    'set-cookie': '_idx=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..Mgwu7HWxw38wd0h9.N3V1VvkvwRjtyEZiLscPWRFeiX1X9yJYAkjrJsTDqPMNSGrPOqxPBvRdEPsc-0GPoZcjssc9Ap19wykbna3SgA.ptZz7fY49P3LoejUU4RYEA; Max-Age=788400000; Path=/; Expires=Sat, 07 Dec 2047 15:00:27 GMT; HttpOnly; SameSite=Lax'
  },
  statusCode: 200,
  body: 'iwaAeyJ0ZXN0Ijoib25lIn0D',
  isBase64Encoded: true
}
```

This PR uses the existing check for whether the method is an async middleware, and then additionally passes just the `set-cookie` header into the res object (if the method is an array and therefore ran through arc.http.async)

_idx cookie is returned in the header correctly, and the session is available on subsequent requests. 