### PR TITLE
Fix for state being empty when using middleware pattern

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -15,6 +15,7 @@ import render from './_render.mjs'
 import fingerprintPaths from './_fingerprint-paths.mjs'
 import compareRoute from './_sort-routes.mjs'
 import path from 'path'
+import { brotliDecompressSync } from 'zlib'
 
 export default async function api (options, req) {
   const { basePath, altPath } = options
@@ -111,7 +112,9 @@ export default async function api (options, req) {
   if (altPath) altHeadElements = await getElements(altPath)
   const head = baseHeadElements.head || altHeadElements.head
   const elements = {...altHeadElements.elements,...baseHeadElements.elements}
-
+  if(isAsyncMiddleware && state.isBase64Encoded && state.headers['content-type'] === 'application/json; charset=utf8') {
+    state.json = JSON.parse(new Buffer.from(brotliDecompressSync(new Buffer.from(state.body, 'base64')), 'base64').toString()) || {}
+  }
   const store = state.json
     ? state.json
     : {}


### PR DESCRIPTION
This fixes #56 

The middleware async function returns brotli compressed, base64 body

This PR adds an additional check for whether the state has been created by a middleware handler, and then if it's base64 encoded, sets `state.json` to the correct json value. 

Components with this fix now have the state populated correctly 

(ps - I looked at expanding the tests from yesterday's PR, and noticed that within the test runner the response from a middleware function isn't base64 encoded and content-encoding: br isn't set in the headers.... i'm not entirely sure how best to construct a test that captures this?)

