### PR TITLE
Fix sort algorithm for deeply nested routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ public/bundles
 sam.json
 sam.yaml
 public/styles.css
+models/enhance-styles

--- a/src/http/any-catchall/_sort-routes.mjs
+++ b/src/http/any-catchall/_sort-routes.mjs
@@ -1,27 +1,31 @@
 /** helper to sort routes from least ambiguous to most */
 export default function sorter(a, b) {
+  // Sorting is done by assinging letters to each part of the path 
+  // and then using alphabetical ordering to sort on.
+  // They are sorted in reverse alphabetical order so that 
+  // extra path parts at the end will rank higher when reversed.
   function pathPartWeight(str) {
     // assign a weight to each path parameter
-    // catchall=1 < dynamic=2 < static=3 < index=4 
-    if (str === '$$.mjs'||str==='$$.html') return 1 
-    if (str.startsWith('$')) return 2 
-    if (!(str==="index.mjs"||str==="index.html")) return 3
-    if (str==="index.mjs"||str==="index.html") return 4
+    // catchall='A' < dynamic='B' < static='C' < index='D'
+    if (str === '$$.mjs'||str==='$$.html') return 'A' 
+    if (str.startsWith('$')) return 'B' 
+    if (!(str==="index.mjs"||str==="index.html")) return 'C'
+    if (str==="index.mjs"||str==="index.html") return 'D'
   }
 
   function totalWeightByPosition(str) {
     // weighted by position in the path
     // /highest/high/low/lower/.../lowest
-    // weigh/1, weight/10, weight/100, weight/1000
     // return result weighted by type and position
-    // i.e. /index.mjs = 4
-    // i.e. /test/index.mjs = 3.4
-    // i.e. /test/this.mjs = 3.3
-    // i.e. /test/$id.mjs = 3.2
-    // i.e. /test/$$.mjs = 3.1
+    // * When sorted in reverse alphabetical order the result is as expected.
+    // i.e. /index.mjs = 'D'
+    // i.e. /test/index.mjs = 'CD'
+    // i.e. /test/this.mjs = 'CC'
+    // i.e. /test/$id.mjs = 'CB'
+    // i.e. /test/$$.mjs = 'CA'
     return str.split('/').reduce((prev, curr, i) => {
-      return (prev + (pathPartWeight(curr) / Math.pow(10, i)))
-    }, 0) 
+      return (prev + (pathPartWeight(curr) ))
+    }, '') 
   }
 
   const aWeight = totalWeightByPosition(a)

--- a/test/_sort-routes.mjs
+++ b/test/_sort-routes.mjs
@@ -64,8 +64,10 @@ test('sort edge case ', t => {
   const good = [
    '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/new.mjs',
    '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$id.mjs',
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$$.mjs',
   ]
   const bad = [
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$$.mjs',
    '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$id.mjs',
    '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/new.mjs',
   ]

--- a/test/_sort-routes.mjs
+++ b/test/_sort-routes.mjs
@@ -59,7 +59,7 @@ test('sort dynamic parts diff positions ', t => {
   t.deepEqual(result,good, 'dynamic parts in different positions sorted')
 })
 
-test('sort edge case ', t => {
+test('sorting with very deeply nested paths', t => {
   t.plan(1)
   const good = [
    '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/new.mjs',

--- a/test/_sort-routes.mjs
+++ b/test/_sort-routes.mjs
@@ -74,6 +74,6 @@ test('sorting with very deeply nested paths', t => {
 
   let result = bad.sort(sorter)
 
-  t.deepEqual(result,good, 'edgecase sorted')
+  t.deepEqual(result,good, 'deeply nested path sorted')
 })
 

--- a/test/_sort-routes.mjs
+++ b/test/_sort-routes.mjs
@@ -56,5 +56,22 @@ test('sort dynamic parts diff positions ', t => {
 
   let result = bad.sort(sorter)
 
-  t.deepEqual(result,good, 'sorted')
+  t.deepEqual(result,good, 'dynamic parts in different positions sorted')
 })
+
+test('sort edge case ', t => {
+  t.plan(1)
+  const good = [
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/new.mjs',
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$id.mjs',
+  ]
+  const bad = [
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/$id.mjs',
+   '/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/new.mjs',
+  ]
+
+  let result = bad.sort(sorter)
+
+  t.deepEqual(result,good, 'edgecase sorted')
+})
+


### PR DESCRIPTION
The previous route sorting algorithm used floating point math to sort routes. Each part of the route would contribute a decimal value and the overall number would be sorted. This works fine until routes get really deep. At between 15 and 17 levels deep on the route the floating point math breaks down. This did not show up as a problem because almost no routing for real apps is nested that deeply. But the in practice the route includes the local path to the route folder combined with the folder routing. So if you have 10 folders to get to your local API folder and then your app routing adds 5 levels the sorting breaks. 

The fix here is instead of assigning a numeric value weighted by decimal place we add a letter weighted by position so that each route has a string that can then be alphabetically sorted for routes. In fact reverse alphabetic order is used so that extra positions at the end can weight higher than shorter route paths.