### PR TITLE
Middleware respects redirect

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -99,8 +99,9 @@ export default async function api (options, req) {
       // just return the api response if
       // - not a GET
       // - no corresponding page
-      // - state.location has been explicitly passed
-      if (req.method.toLowerCase() != 'get' || !pagePath || state.location) {
+      // - location has been explicitly passed
+      let location = state.location || (state.headers && state.headers["Location"])
+      if (req.method.toLowerCase() != 'get' || !pagePath || location) {
         return state
       }
       

--- a/test/mock-async-middleware/app/api/test-redirect.mjs
+++ b/test/mock-async-middleware/app/api/test-redirect.mjs
@@ -1,0 +1,13 @@
+export let get = [one, two]
+
+async function one (req) {
+  // should exit middleware and redirect to /login
+  return {
+    location: "/login"
+  }
+}
+
+async function two (req) {
+  // should not enter via middleware
+  throw "Should never be reached."
+}

--- a/test/mock-async-middleware/app/pages/test-redirect.html
+++ b/test/mock-async-middleware/app/pages/test-redirect.html
@@ -1,0 +1,1 @@
+<p>Should never be reached.</p>

--- a/test/router-async-middleware.mjs
+++ b/test/router-async-middleware.mjs
@@ -21,3 +21,20 @@ test('router middleware passes values', async t => {
   t.ok(res.headers['set-cookie'], 'got a set-cookie header')
   console.log(res)
 })
+
+test('router middleware respects redirects', async t => {
+  t.plan(2)
+  let req = {
+    rawPath: '/test-redirect',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html',
+    },
+  }
+  process.env.ARC_SESSION_TABLE_NAME = 'jwe' // if we do not do this we need to setup dynamo!
+  let basePath = path.join(__dirname, 'mock-async-middleware', 'app')
+  let res = await router.bind({}, { basePath })(req)
+  t.equals(res.headers["Location"], "/login", "req location matches")
+  t.equals(res.statusCode, 302, "proper redirect status")
+  console.log(res);
+})


### PR DESCRIPTION
I discovered middleware was not respecting the redirection concept due to `arc.http.async` doing a response formatting that moves the `state.location` to the headers of the response. This was problematic in enhance because the `state.location` never exists after the async combined method is run, and it never checks the headers for it.

The use-case I wanted is for any middleware to handle the `return { location: "/login" }` style termination. This was failing to be respected accordingly.

When I say `arc.http.async` is formatting the Location of the response, I'm referencing this line: https://github.com/architect/functions/blob/ddc43ecbc23f9481a1bb1c039fe4f444bfffcf2a/src/http/_res-fmt.js#L164
