### PR TITLE
Rename folder that maps to @architect/shared

### DIFF
--- a/src/plugins/beginner.js
+++ b/src/plugins/beginner.js
@@ -49,7 +49,7 @@ module.exports = {
     shared ({ inventory }) {
       const cwd = inventory.inv._project.cwd
       return {
-        src: join(cwd, 'models')
+        src: join(cwd, 'shared')
       }
     },
 


### PR DESCRIPTION
Currently this plugin maps `@architect/shared` to the `<PROJECT_DIR>/models` folder. This is a bit confusing as it is not the `<PROJECT_DIR>/app/models` folder we use to share code between Enhance API, elements, pages, etc. 

I've recently run into the need for the `@architect/shared` functionality when needing to add an Architect plugin to my Enhance app and then once again when attempting to share code between my `app` folder and `jobs` folder.

This is a simple change, but a breaking one. Mostly, I'm raising this PR to begin the conversation as to how we should handle `@architect/shared` in an Enhance app.