### PR TITLE
redirect big ones

### DIFF
--- a/src/http/get-_public-catchall/index.mjs
+++ b/src/http/get-_public-catchall/index.mjs
@@ -2,5 +2,15 @@ import asap from '@architect/asap'
 
 export async function handler (req) {
   req.rawPath = req.rawPath.replace('/_public', '')
-  return asap()(req)
+  const response = await asap()(req)
+  console.log('response: ', response)
+  const size = response?.body?.length
+  console.log(`size: ${size}`)
+  if (size > 5500000) {      // 5.5MB
+    return {
+      statusCode: 302,
+      headers: { Location: `/_static${req.rawPath}` }
+    }
+  }
+  return response
 }

--- a/src/http/get-_public-catchall/index.mjs
+++ b/src/http/get-_public-catchall/index.mjs
@@ -3,9 +3,7 @@ import asap from '@architect/asap'
 export async function handler (req) {
   req.rawPath = req.rawPath.replace('/_public', '')
   const response = await asap()(req)
-  console.log('response: ', response)
   const size = response?.body?.length
-  console.log(`size: ${size}`)
   if (size > 5500000) {      // 5.5MB
     return {
       statusCode: 302,


### PR DESCRIPTION
Redirect big assets from _public to _static to gain a few MB's of margin for big assets