### PR TITLE
Middleware location header fix

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -94,7 +94,12 @@ export default async function api (options, req) {
 
       // if the user-agent requested json return the response immediately
       if (isJSON(req.headers)) {
-        delete state.location
+        if (!isAsyncMiddleware) {
+          delete state.location
+        }
+        else {
+          delete state.headers.location
+        }
         return state
       }
 


### PR DESCRIPTION
If you are requesting a JSON response and have specified an array of functions to run. For example:

```javascript
export const post = [checkAuth, createLink]
```

and your return from the `createLink` function is:

```javascript
    return {
      session: newSession,
      json: { link: result },
      location: '/links'
    }
```

You expect to get the JSON payload and not be redirected to `/links`. 

This small code change makes it possible.