### PR TITLE
Fix headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "start": "sandbox",
     "lint": "eslint . --fix",
-    "test": "tape test/*.mjs | tap-arc"
+    "test": "tape test/*.mjs | tap-arc",
+    "t": "tape test/router.mjs | tap-arc"
   },
   "files": [
     "app/*",

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -191,6 +191,10 @@ export default async function api (options, req) {
       const { 'content-type': contentType, 'content-encoding': contentEncoding, ...otherHeaders } = state.headers
       res.headers = otherHeaders
     }
+    else if (!!res.headers === false && state.headers) {
+      // always pass headers!
+      res.headers = state.headers
+    }
     return res
   }
   catch (err) {

--- a/test/mock-headers/app/api/index.mjs
+++ b/test/mock-headers/app/api/index.mjs
@@ -1,0 +1,32 @@
+// View documentation at: https://enhance.dev/docs/learn/starter-project/api
+/**
+ * @typedef {import('@enhance/types').EnhanceApiFn} EnhanceApiFn
+ */
+
+/**
+ * @type {EnhanceApiFn}
+ *
+ * testing a custom header
+ */
+export async function get () {
+  return {
+    headers: {
+      'x-custom-header': 'custom-header-value',
+    },
+    json: { data: [ 'sutro', 'turtle', 'mae mae' ] }
+  }
+}
+
+/**
+ * @type {EnhanceApiFn}
+ *
+ * testing a custom header in midddleware
+ */
+export let post = [async function fn () {
+  return {
+    headers: {
+      'x-custom-header': 'custom-header-value',
+    },
+    json: { data: [ 'sutro', 'turtle', 'mae mae' ] }
+  }
+}]

--- a/test/mock-headers/app/pages/index.html
+++ b/test/mock-headers/app/pages/index.html
@@ -1,0 +1,1 @@
+<figure>fun new (to me) element</figure>

--- a/test/router.mjs
+++ b/test/router.mjs
@@ -32,5 +32,61 @@ test('router with no pages folder', async t => {
   let base = path.join(__dirname, 'mock-folders', 'app')
   let result = await router({ basePath: base }, req)
   t.ok(result, 'got result')
+})
+
+test('headers pass thru application/json', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'get',
+    headers: {
+      'accept': 'application/json'
+    }
+  }
+  let base = path.join(__dirname, 'mock-headers', 'app')
+  let result = await router({ basePath: base }, req)
+  t.ok(result.headers['x-custom-header'] === 'custom-header-value', 'x-custom-header: custom-header-value')
+})
+
+test('headers pass thru application/json middleware', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'post',
+    headers: {
+      'accept': 'application/json'
+    }
+  }
+  let base = path.join(__dirname, 'mock-headers', 'app')
+  let result = await router({ basePath: base }, req)
+  t.ok(result.headers['x-custom-header'] === 'custom-header-value', 'x-custom-header: custom-header-value')
+})
+
+test('headers pass thru text/html', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'get',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let base = path.join(__dirname, 'mock-headers', 'app')
+  let result = await router({ basePath: base }, req)
+  t.ok(result.headers['x-custom-header'] === 'custom-header-value', 'x-custom-header: custom-header-value')
   console.log(result)
+})
+
+test('headers pass thru text/html middleware', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/',
+    method: 'post',
+    headers: {
+      'accept': 'text/html'
+    }
+  }
+  let base = path.join(__dirname, 'mock-headers', 'app')
+  let result = await router({ basePath: base }, req)
+  t.ok(result.headers['x-custom-header'] === 'custom-header-value', 'x-custom-header: custom-header-value')
 })


### PR DESCRIPTION
ensure whenever an api route returns `{headers}` that they get passed through to the final request