### PR TITLE
Add `Server-Timing` headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,15 @@
     "@enhance/import-transform": "^4.0.0",
     "@enhance/ssr": "^3.5.0",
     "glob": "^9.2.1",
+    "header-timers": "^0.0.1",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {
-    "@architect/eslint-config": "^2.1.1",
-    "@architect/sandbox": "^5.8.0",
-    "eslint": "^8.47.0",
-    "tap-arc": "^0.3.5",
-    "tape": "^5.6.6",
+    "@architect/eslint-config": "^2.1.2",
+    "@architect/sandbox": "^5.9.2",
+    "eslint": "^8.52.0",
+    "tap-arc": "^1.2.2",
+    "tape": "^5.7.2",
     "tiny-json-http": "^7.5.1"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@enhance/import-transform": "^4.0.0",
     "@enhance/ssr": "^3.5.0",
     "glob": "^9.2.1",
-    "header-timers": "^0.0.3",
+    "header-timers": "^0.1.0",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@enhance/import-transform": "^4.0.0",
     "@enhance/ssr": "^3.5.0",
     "glob": "^9.2.1",
-    "header-timers": "^0.0.1",
+    "header-timers": "^0.0.3",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -167,13 +167,13 @@ export default async function api (options, req) {
 
   function addTimingToHeaders (res) {
     const { headers = {} } = res
-    const { [timers.headerKey]: existing = null } = headers
-    const timingValue = timers.headerValue()
+    const { [timers.key]: existing = null } = headers
+    const timingValue = timers.value()
     return {
       ...res,
       headers: {
         ...headers,
-        [timers.headerKey]: existing
+        [timers.key]: existing
           ? `${existing}, ${timingValue}`
           : timingValue
       }


### PR DESCRIPTION
This includes some random guy's `header-timers` tool to create timing headers for the server response.

I added 4 obvious (to me) timers. But there is likely an opportunity to add more. Also they can be enabled/disabled per request. If they are disabled, the `timers`' methods just noop.

Also, if a consumer dev is already creating `Server-Timing` headers, this should play nice. Though, I haven't written any tests yet.

Here's a sample from a site with ~35 elements or so and an API call that includes fetching from Dynamo. The first 2 entries are custom timings from the app; the last 4 are the timers added so far in this PR

![image](https://github.com/enhance-dev/arc-plugin-enhance/assets/15697/2e86c916-92b9-4e69-8222-6ce069de739c)
