### PR TITLE
async Preflight

### DIFF
--- a/src/http/any-catchall/_get-preflight.mjs
+++ b/src/http/any-catchall/_get-preflight.mjs
@@ -2,11 +2,16 @@ import fs from 'fs'
 import { join } from 'path'
 import { pathToFileURL } from 'url'
 
-export default async function GetPreflight({ basePath = '' }) {
+export default async function GetPreflight ({ basePath = '' }) {
   const localPath = join(basePath, 'preflight.mjs')
   if (fs.existsSync(localPath)) {
-    const { default: preflight } = await import(pathToFileURL(localPath).href)
-    return preflight
+    try {
+      const { default: preflight } = await import(pathToFileURL(localPath).href)
+      return preflight
+    }
+    catch (error) {
+      throw new Error(`Issue when trying to import preflight: ${localPath}`, { cause: error })
+    }
   }
 }
 

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -68,6 +68,13 @@ export default async function api (options, req) {
   let state = {}
   let isAsyncMiddleware = false
 
+  let preflightData = {}
+  if (preflight) {
+    timers.start('preflight', 'enhance-preflight')
+    preflightData = await preflight({ req })
+    timers.stop('preflight')
+  }
+
   // rendering a json response or passing state to an html response
   if (apiPath) {
 
@@ -143,17 +150,9 @@ export default async function api (options, req) {
   let elements = { ...altHeadElements.elements, ...baseHeadElements.elements }
   timers.stop('elements')
 
-
-  let store
-  let mergeState = state.json ? state.json : {}
-
-  if (preflight) {
-    timers.start('preflight', 'enhance-preflight')
-    store = Object.assign(await preflight({ req }), mergeState)
-    timers.stop('preflight')
-  }
-  else {
-    store = mergeState
+  let store = {
+    ...(state.json || {}),
+    ...preflightData
   }
 
   function html (str, ...values) {

--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -148,7 +148,9 @@ export default async function api (options, req) {
   let mergeState = state.json ? state.json : {}
 
   if (preflight) {
-    store = Object.assign(preflight({ req }), mergeState)
+    timers.start('preflight', 'enhance-preflight')
+    store = Object.assign(await preflight({ req }), mergeState)
+    timers.stop('preflight')
   }
   else {
     store = mergeState
@@ -168,9 +170,7 @@ export default async function api (options, req) {
     timers.start('html', 'enhance-html')
     const htmlString = _html(str, ...values)
     timers.stop('html')
-    timers.start('fingerprint', 'enhance-fingerprint')
     const fingerprinted = fingerprintPaths(htmlString)
-    timers.stop('fingerprint')
     return fingerprinted
   }
 


### PR DESCRIPTION
> Apologies if I'm missing context here and this was discussed earlier! Already a big fan of the preflight feature.

## What?
Make preflight function execution async

## Use Case
I want to talk to a database to fetch the weather (or any cached data) in my preflight function. Currently the preflight result is not awaited.

## Alternative solution
My app could run the query in each route's API function (which is async ofc), but that would require each route to have an API file.

## Other changes:
- add preflight timers - this makes sense if they can be async, could be a perf killer
- remove fingerprint timers - after a couple months of usage, I've never seen this timer exceed 0ms

## Did you test this?
Yeah in Sandbox, with both async and sync preflight functions. Works as expected. I didn't see an obvious vector to add an automated test.