### PR TITLE
remove zlib from any-catchall package

### DIFF
--- a/src/http/any-catchall/package.json
+++ b/src/http/any-catchall/package.json
@@ -8,7 +8,6 @@
     "@enhance/ssr": "^3.5.1",
     "glob": "^9.3.5",
     "header-timers": "^0.2.0",
-    "path-to-regexp": "^6.2.1",
-    "zlib": "^1.0.5"
+    "path-to-regexp": "^6.2.1"
   }
 }


### PR DESCRIPTION
I think we were eager to fix the recent hydration issue and included `zlib` in any-catchall package.json. This means consumers will have to install the 12 year old module from npm even though Enhance uses the Node built-in `node:zlib`.

This causes long install times or even install failures (old zlib uses node-waf)

```
✓ Hydrate Hydrated node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/
  | npm i --omit=dev: added 317 packages, and audited 318 packages in 23s
```

This patch removes `zlib` from package.json.
`npm i` for this Lambda goes to ~600ms in my dev env :)