### PR TITLE
Fix Windows issue with HTML elements

### DIFF
--- a/src/http/any-catchall/_get-elements.mjs
+++ b/src/http/any-catchall/_get-elements.mjs
@@ -140,7 +140,7 @@ export default async function getElements (basePath) {
         }
       }
       else {
-        let template = readFileSync(fileURL.pathname)
+        let template = readFileSync(e)
         els[tag] = HTMLElementWrapper({ template: template.toString() })
       }
     }

--- a/test/mock-html-elements/app/elements/html-element.html
+++ b/test/mock-html-elements/app/elements/html-element.html
@@ -1,0 +1,3 @@
+<div>
+  <p>This is a HTML only element.</p>
+</div>

--- a/test/mock-html-elements/app/pages/test-element.html
+++ b/test/mock-html-elements/app/pages/test-element.html
@@ -1,0 +1,1 @@
+<html-element></html-element>

--- a/test/router-html-element.mjs
+++ b/test/router-html-element.mjs
@@ -1,0 +1,20 @@
+import test from 'tape'
+import url from 'url'
+import path from 'path'
+import router from '../src/http/any-catchall/router.mjs'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+test('router page with html element', async t => {
+  t.plan(1)
+  let req = {
+    rawPath: '/test-element',
+    method: 'GET',
+    headers: {
+      'accept': 'text/html',
+    },
+  }
+  let basePath = path.join(__dirname, 'mock-html-elements', 'app')
+  let res = await router.bind({}, { basePath })(req)
+  t.ok(res.html.includes('This is a HTML only element.'), 'rendered html only elements')
+})


### PR DESCRIPTION
The `_get_elements.mjs` file was failing when trying to load a HTML file. `fileURL.pathname` works on UNIX but not windows because it adds and extra `/` at the start of a Windows path, i.e. `/C:/Users/`. Switching to using the file path and not url file path works on both Windows and UNIX.