### PR TITLE
Better error for async middleware

### DIFF
--- a/src/http/any-catchall/router.mjs
+++ b/src/http/any-catchall/router.mjs
@@ -89,8 +89,14 @@ export default async function api (options, req) {
 
     let method = req.method.toLowerCase() !== 'delete' ? mod[req.method.toLowerCase()] : mod['destroy']
     isAsyncMiddleware = Array.isArray(method)
-    if (isAsyncMiddleware)
+    if (isAsyncMiddleware) {
+      method.forEach(step => {
+        if (step.constructor.name !== 'AsyncFunction') {
+          throw Error(`Middleware function "${step.name}" for "${req.path}" is not an async function. All middleware functions must be "async".`)
+        }
+      })
       method = arc.http.apply(null, method)
+    }
     if (method) {
 
       // check to see if we need to modify the req and add in params


### PR DESCRIPTION
If you accidentally set a synchronous function as one of your middleware steps an error will be thrown.

```
Oops, something went wrong
TypeError: Cannot destructure property 'content-type' of 'state.headers' as it is undefined.
    at Object.api (file:///Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/router.mjs:236:31)
    at async lambda (/Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@architect/functions/src/http/index.js:37:22)
```

Which is not very helpful. 

With this change the error changes to:

```
Lambda error
Error: Error: Middleware function "isAdmin" for "/admin/" is not an async function. All middleware functions must be "async".
Lambda: @http any /*
Source: /Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall
: Middleware function "isAdmin" for "/admin/" is not an async function. All middleware functions must be "async".

Stack trace:
Error: Middleware function "isAdmin" for "/admin/" is not an async function. All middleware functions must be "async".,    at file:///Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/router.mjs:95:17,    at Array.forEach (),    at Object.api (file:///Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@enhance/arc-plugin-enhance/src/http/any-catchall/router.mjs:93:14),    at async lambda (/Users/simonmacdonald/Developer/macdonst/js-quiz/node_modules/@architect/functions/src/http/index.js:37:22)
```

So more descriptive and should help folks find their error quickly.