### PR TITLE
fix: broken static assets if using a remotely-connected arc sandbox.

### DIFF
--- a/src/http/any-catchall/_fingerprint-paths.mjs
+++ b/src/http/any-catchall/_fingerprint-paths.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import url from 'url'
-const _local = process.env.ARC_ENV === 'testing'
+const _local = process.env.ARC_ENV === 'testing' || process.env.ARC_LOCAL
 
 let manifest = {}
 if (!_local) {


### PR DESCRIPTION
you can connect a local arc sandbox to remotely-deployed infra (like database tables) by setting `ARC_ENV`, `ARC_STACK_NAME` and `ARC_LOCAL`. This [is (barely) documented on the `arc sandbox` docs](https://arc.codes/docs/en/reference/cli/sandbox#live-database-example).

So, in case someone is using that feature (like me and @remy are and [discussed about over in Discord](https://discord.com/channels/1012099764713705472/1012435743571988560/1417781365457555530)) need to also check for `ARC_LOCAL` to disable static asset fingerprinting.

can confirm this fixes the issue in my enhance+arc app.